### PR TITLE
Fix invalid markup in certifications section

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,8 +155,6 @@
                     <header>
                         <h2>Certifications</h2>
                     </header>
-                    </a>
-                    <p>
                     <ul>
                         <li><a
                                 href="https://www.credly.com/badges/cdcca7ea-6962-4019-919c-650b4fa4778a/linked_in_profile">AWS
@@ -171,7 +169,6 @@
                         <li><a href="https://www.udemy.com/certificate/UC-bfe856f2-9626-4dde-a88c-082ddb4819c6">Design
                                 Patterns in TypeScript (2021)</a></li>
                     </ul>
-                    </p>
                 </article>
             </section>
             <section class="split education">


### PR DESCRIPTION
## Summary
- remove stray closing `</a>` and `<p>` tags in certifications section

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c45687c48332bb0d9a694a825c74