### PR TITLE
Fix navList variable declarations to avoid globals

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -6,7 +6,7 @@
 	 */
 	$.fn.navList = function() {
 
-		var	$this = $(this);
+		var	$this = $(this),
 			$a = $this.find('a'),
 			b = [];
 


### PR DESCRIPTION
## Summary
- fix util.js navList to declare `$a` and `b` with `var` to avoid unintended globals

## Testing
- `node --check assets/js/util.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2086a98dc8332bac29e232313d210