### PR TITLE
refactor: update title, tagline, and WBD role to Technical Lead II (v…

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,22 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Debraj Paul &#8212; Senior Backend / Platform Engineer (Node.js &middot; TypeScript &middot; AWS)</title>
+  <title>Debraj Paul &#8212; Technical Lead II, Backend / Platform (Node.js &middot; TypeScript &middot; AWS)</title>
   <meta name="description" content="Senior Platform / Backend Engineer with 11+ years building distributed, event-driven systems on AWS. Open to remote roles globally." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://debrajpaul.com/" />
-  <meta property="og:title" content="Debraj Paul &#8212; Senior Backend / Platform Engineer" />
+  <meta property="og:title" content="Debraj Paul &#8212; Technical Lead II, Backend / Platform" />
   <meta property="og:description" content="Senior Platform / Backend Engineer with 11+ years building distributed, event-driven systems on AWS. Open to remote roles globally." />
   <meta property="og:site_name" content="Debraj Paul" />
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="Debraj Paul &#8212; Senior Backend / Platform Engineer" />
+  <meta name="twitter:title" content="Debraj Paul &#8212; Technical Lead II, Backend / Platform" />
   <meta name="twitter:description" content="Senior Platform / Backend Engineer with 11+ years building distributed, event-driven systems on AWS. Open to remote roles globally." />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Person",
     "name": "Debraj Paul",
-    "jobTitle": "Senior Backend / Platform Engineer",
+    "jobTitle": "Technical Lead II — Backend / Platform Engineer",
     "url": "https://debrajpaul.com",
     "email": "debraj@debrajpaul.com",
     "sameAs": [
@@ -29,7 +29,7 @@
       "Node.js","TypeScript","JavaScript","AWS","Microservices",
       "Event-Driven Systems","GraphQL","Distributed Systems","Kafka",
       "DynamoDB","Lambda","ECS","Docker","OpenTelemetry","GDPR","CCPA",
-      "Redis","OpenSearch","AWS Glue","OneTrust"
+      "Redis","OpenSearch","AWS Glue","OneTrust","Amazon Bedrock"
     ]
   }
   </script>
@@ -290,7 +290,7 @@
       <div class="container">
         <p class="eyebrow">Bengaluru, IN &middot; Remote-first globally &middot; Open to relocation</p>
         <h1 id="hero-h1">Debraj Paul</h1>
-        <p class="hero-tagline">Senior Backend / Platform Engineer &mdash; Node.js &middot; TypeScript &middot; AWS</p>
+        <p class="hero-tagline">Technical Lead II &mdash; Backend / Platform &middot; Node.js &middot; TypeScript &middot; AWS</p>
         <p class="hero-pos">
           11+ years designing, building, and operating distributed backend systems across media, fintech, food-tech, and travel.
           Deep in AWS-native architectures, event-driven platforms, and Backend-for-Frontend GraphQL.
@@ -344,7 +344,7 @@
     <section class="section-open-to" id="open-to">
       <div class="container">
         <blockquote class="callout-open fade-in-el">
-          <strong>Open to:</strong> Senior backend / Staff IC roles. Remote-first globally &middot; Hybrid in India &middot; Open to relocation. Comfortable across time zones.
+          <strong>Open to:</strong> Senior Staff / Principal Engineer &middot; Senior Tech Lead &middot; Technical Architect. Remote-first globally &middot; Hybrid in India &middot; Open to relocation. Comfortable across time zones.
         </blockquote>
       </div>
     </section>
@@ -359,7 +359,7 @@
           <article class="work-card fade-in-el" aria-labelledby="card-wbd">
             <header class="card-header">
               <span class="card-company" id="card-wbd">Warner Bros. Discovery <span style="color:var(--muted);font-weight:400">via Robosoft</span></span>
-              <span class="card-role">Senior Software Engineer</span>
+              <span class="card-role">Senior Software Engineer &mdash; Technical Lead II <span style="color:var(--muted);font-weight:400">(promoted Jan 2026)</span></span>
               <span class="card-dates">Aug 2021 &mdash; Present &middot; Remote</span>
             </header>
             <p class="card-context">Global, high-traffic media platform serving multiple brands with personalization, CMS, BFF services, and compliance-critical workflows.</p>
@@ -735,7 +735,7 @@
           <li class="fade-in-el">
             <div class="timeline-dot" aria-hidden="true"></div>
             <div class="timeline-company">Warner Bros. Discovery <span style="color:var(--muted);font-weight:400;font-size:0.875rem">via Robosoft</span></div>
-            <div class="timeline-role">Senior Software Engineer</div>
+            <div class="timeline-role">Senior Software Engineer &mdash; Technical Lead II <span style="color:var(--muted);font-weight:400">(promoted Jan 2026)</span></div>
             <div class="timeline-meta">Aug 2021 &mdash; Present &middot; Remote (Washington DC / Bengaluru)</div>
           </li>
           <li class="fade-in-el">


### PR DESCRIPTION
…3 prompt)

- <title>, og:title, twitter:title → "Technical Lead II, Backend / Platform"
- JSON-LD jobTitle → "Technical Lead II — Backend / Platform Engineer"
- JSON-LD knowsAbout: add "Amazon Bedrock"
- Hero tagline → "Technical Lead II — Backend / Platform · Node.js · TypeScript · AWS"
- Open-to callout → "Senior Staff / Principal Engineer · Senior Tech Lead · Technical Architect"
- WBD card role + timeline: show promotion to Technical Lead II (Jan 2026)

Deploy: merge to main; GitHub Pages will rebuild within ~1 min.